### PR TITLE
Fix runner serde example header

### DIFF
--- a/runner/README.md
+++ b/runner/README.md
@@ -46,7 +46,7 @@ $ runner --build
 runner rand-example.rs
 ```
 
-## #Serde Example
+### Serde Example
 
 #### Source
 


### PR DESCRIPTION
Fix formatting error where `Serde Example` is H2 instead of H3.